### PR TITLE
Fix: Symbol's value as variable is void: while

### DIFF
--- a/evil-indent-textobject.el
+++ b/evil-indent-textobject.el
@@ -65,13 +65,13 @@ end of the block surrounding point."
     (let ((start (point))
           (indent (evil-indent--current-indentation))
           begin end)
-      (loop while (and (/= (point) (point-min))
+      (cl-loop while (and (/= (point) (point-min))
                        (string= (evil-indent--current-indentation) indent))
             do (progn
                  (setq begin (point-at-bol))
                  (forward-line -1)))
       (goto-char start)
-      (loop while (and (/= (point) (point-max))
+      (cl-loop while (and (/= (point) (point-max))
                        (string= (evil-indent--current-indentation) indent))
             do (progn
                  (setq end (point-at-eol))


### PR DESCRIPTION
I use Emacs 24.4.1. 
When I tried to use your plugin the following error raised: Symbol's value as variable is void: while.
Proposed changes fixed the error for me.

PS: thanks for useful plugin!
